### PR TITLE
🔀👷 Add app signing in github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - ci/build-cert # Temporyry branch for testing
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?'
 env:
   FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"
@@ -23,9 +23,11 @@ jobs:
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
 
       - name: Install dependencies
         run: flutter pub get
+
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,20 +57,20 @@ jobs:
 
       - name: Rename APK & App Bundle
         run: |
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
+          path: build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab
+          path: build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab
 
       - name: Release Artifacts
         uses: softprops/action-gh-release@v2
@@ -78,5 +78,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
-            build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab
+            build/app/outputs/flutter-apk/GitDone_${{ github.ref_name }}.apk
+            build/app/outputs/bundle/release/GitDone_${{ github.ref_name }}.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
-          path: ~/android/sdk/
+          path: /usr/local/lib/android/sdk/ndk
           key: ${{ runner.os }}-ndk-${{ hashFiles('**/build.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-sdk-
+            ${{ runner.os }}-ndk-
 
       - uses: actions/checkout@v4
 
@@ -48,6 +48,9 @@ jobs:
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
           echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > android/app/key.jks
+
+      - name: List installed NDK versions
+        run: ls $ANDROID_SDK_ROOT/ndk
 
       - name: Build APK
         run: flutter build apk --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 env:
   FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"
@@ -15,6 +17,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/android-sdk
+          key: ${{ runner.os }}-android-sdk-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-android-sdk-
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cmake
+          key: ${{ runner.os }}-cmake-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/ndk
+          key: ${{ runner.os }}-ndk-${{ hashFiles('**/build.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-ndk-
+
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Rename APK & App Bundle
         run: |
-          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
-          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             build/app/outputs/flutter-apk/app-release.apk
             build/app/outputs/bundle/release/app-release.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
-          path: ./android/sdk/
+          path: ~/android/sdk/
           key: ${{ runner.os }}-ndk-${{ hashFiles('**/build.gradle') }}
           restore-keys: |
             ${{ runner.os }}-sdk-
@@ -55,17 +55,22 @@ jobs:
       - name: Build App Bundle
         run: flutter build appbundle --release
 
+      - name: Rename APK & App Bundle
+        run: |
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab
+
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
+          path: build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: build/app/outputs/bundle/release/app-release.aab
+          path: build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab
 
       - name: Release Artifacts
         uses: softprops/action-gh-release@v2
@@ -73,5 +78,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            build/app/outputs/flutter-apk/app-release.apk
-            build/app/outputs/bundle/release/app-release.aab
+            build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
+            build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
+          path: build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: release-appbundle
-          path: build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab
+          path: build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab
 
       - name: Release Artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+env:
+  JAVA_VERSION: "21"
+  FLUTTER_VERSION: "3.29.2"
+  FLUTTER_CHANNEL: "stable"
+  PROPERTIES_PATH: "./android/key.properties"
 
 jobs:
   build:
@@ -15,8 +20,8 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: stable
-          flutter-version: '3.29.2'
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install dependencies
         run: flutter pub get
@@ -25,13 +30,29 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: $${ env.JAVA_VERSION }
+
+      - name: Set up keystore
+        run: |
+          echo keyPassword=\${{ secrets.KEY_STORE }} > ${{env.PROPERTIES_PATH}}
+          echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
+          echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
+          echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > android/app/key.jks
 
       - name: Build APK
         run: flutter build apk --release
+
+      - name: Build App Bundle
+        run: flutter build appbundle --release
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
           path: build/app/outputs/flutter-apk/app-release.apk
+
+      - name: Upload App Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,5 +78,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            build/app/outputs/flutter-apk/GitDone_${{ github.event.ref }}.apk
-            build/app/outputs/bundle/release/GitDone_${{ github.event.ref }}.aab
+            build/app/outputs/flutter-apk/GitDone_${{ github.event.ref_name }}.apk
+            build/app/outputs/bundle/release/GitDone_${{ github.event.ref_name }}.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
-name: Build APK
+name: Build APK & App Bundle
 
 on:
   push:
-    branches:
-      - ci/build-cert # Temporyry branch for testing
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?'
 env:
@@ -57,5 +55,13 @@ jobs:
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
-          name: release-apk
-          path: build/app/outputs/flutter-apk/app-release.aab
+          name: release-appbundle
+          path: build/app/outputs/bundle/release/app-release.aab
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/app/outputs/flutter-apk/app-release.apk
+            build/app/outputs/bundle/release/app-release.aab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,24 +19,10 @@ jobs:
     steps:
       - uses: actions/cache@v4
         with:
-          path: ${{ runner.tool_cache }}/android-sdk
-          key: ${{ runner.os }}-android-sdk-${{ hashFiles('**/build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-android-sdk-
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ runner.tool_cache }}/cmake
-          key: ${{ runner.os }}-cmake-${{ hashFiles('**/build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-cmake-
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ runner.tool_cache }}/ndk
+          path: ./android/sdk/
           key: ${{ runner.os }}-ndk-${{ hashFiles('**/build.gradle') }}
           restore-keys: |
-            ${{ runner.os }}-ndk-
+            ${{ runner.os }}-sdk-
 
       - uses: actions/checkout@v4
 
@@ -81,7 +67,7 @@ jobs:
           name: release-appbundle
           path: build/app/outputs/bundle/release/app-release.aab
 
-      - name: Release
+      - name: Release Artifacts
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build APK & App Bundle
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?'
+      - 'v*'
 env:
   FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,18 @@ name: Build APK
 
 on:
   push:
+    branches:
+      - ci/build-cert # Temporyry branch for testing
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 env:
-  JAVA_VERSION: "21"
   FLUTTER_VERSION: "3.29.2"
   FLUTTER_CHANNEL: "stable"
   PROPERTIES_PATH: "./android/key.properties"
 
 jobs:
   build:
-    name: Build APK
+    name: Build APK & App Bundle
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +31,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: $${ env.JAVA_VERSION }
+          java-version: '21'
 
       - name: Set up keystore
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/android/sdk/ndk
-          key: ${{ runner.os }}-ndk-${{ hashFiles('**/build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-ndk-
-
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
@@ -48,9 +41,6 @@ jobs:
           echo storePassword=\${{ secrets.KEY_PASSWORD }} >> ${{env.PROPERTIES_PATH}}
           echo keyAlias=\${{ secrets.KEY_ALIAS }} >> ${{env.PROPERTIES_PATH}}
           echo "${{ secrets.KEYSTORE2 }}" | base64 --decode > android/app/key.jks
-
-      - name: List installed NDK versions
-        run: ls $ANDROID_SDK_ROOT/ndk
 
       - name: Build APK
         run: flutter build apk --release

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,9 +36,8 @@ android {
         keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
     }
     signingConfigs {
-        release {
+        create("release") {
             storeFile = file('key.jks')
-
             keyAlias keystoreProperties['keyAlias']
             keyPassword keystoreProperties['keyPassword']
             storePassword keystoreProperties['storePassword']
@@ -46,7 +45,7 @@ android {
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,11 +31,19 @@ android {
         versionName = flutter.versionName
     }
 
+    def keystoreProperties = new Properties()
+    def keystorePropertiesFile = rootProject.file('key.properties')
+    if (keystorePropertiesFile.exists()) {
+        keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            storeFile = file('key.jks')
+
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storePassword keystoreProperties['storePassword']
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,20 +30,23 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
-
     def keystoreProperties = new Properties()
     def keystorePropertiesFile = rootProject.file('key.properties')
     if (keystorePropertiesFile.exists()) {
         keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
     }
-
-    buildTypes {
+    signingConfigs {
         release {
             storeFile = file('key.jks')
 
             keyAlias keystoreProperties['keyAlias']
             keyPassword keystoreProperties['keyPassword']
             storePassword keystoreProperties['storePassword']
+        }
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
This pull request includes significant updates to the build configuration for both APK and App Bundle, along with changes to the signing configuration for the release build. The most important changes are summarized below:

### Build Configuration Updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R75): Updated the workflow to build both APK and App Bundle, added environment variables, and set up permissions. Also included steps to rename and upload the artifacts, and release them as GitHub artifacts.

### Signing Configuration:

* [`android/app/build.gradle`](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L32-R47): Added a new signing configuration for the release build using properties from a `key.properties` file, replacing the previous debug signing configuration.